### PR TITLE
feature/issue 904 check dependency licenses

### DIFF
--- a/approved_licenses.csv
+++ b/approved_licenses.csv
@@ -1,0 +1,23 @@
+License
+0BSD
+"AFLv2.1,BSD"
+Apache-2.0
+BSD
+BSD-2-Clause
+BSD-3-Clause
+CC0-1.0
+CC-BY-3.0
+CC-BY-3.0
+CC-BY-4.0
+ISC
+MIT AND Apache-2.0
+MIT AND BSD-3-Clause
+MIT AND CC-BY-3.0
+MIT
+Public Domain
+Unlicense
+WTFPL
+BSD*
+(MIT AND Apache-2.0)
+(MIT AND BSD-3-Clause)
+(MIT AND CC-BY-3.0)

--- a/scripts/validate-licenses.sh
+++ b/scripts/validate-licenses.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+function print_unapproved () {
+    gawk '
+    BEGIN {
+        FPAT = "([^,]+)|(\"[^\"]+\")"
+        count = 1
+    }
+    NR > 1{
+        gsub(/"/, "")
+        print "\033[1;31m"count " \033[0m"$1 " (\033[34m"$3"\033[0m): \033[1;31m"$2"\033[0m"
+        count++
+    }
+    END {
+    }
+    ' unapproved.csv
+}
+echo -e "Validating package dependecy licenses against approved list...\n"
+
+approved=$(gawk '
+BEGIN {
+    FPAT = "([^,]+)|(\"[^\"]+\")"
+}
+NR > 1{
+    printf("%s,", $1)
+}
+END {
+}
+' devops/scripts/approved_licenses.csv)
+
+echo -e "\033[32mApproved licenses:\033[0m $approved \n"
+
+npx --ignore-existing license-checker --direct --production --excludePrivatePackages --exclude $approved --start . --csv --out unapproved.csv
+
+lines=$(cat unapproved.csv | wc -l)
+
+if [ $lines > 1 ]
+then
+    echo -e "The following \033[1;31m $lines packages \033[0m have licenses that are not in the approved list. Please investigate their licenses and add them to the approved list if compatible with MIT or remove the dependency\n"
+    print_unapproved
+    exit 1
+else
+    echo "All direct dependencies have approved licenses"
+    exit 0
+fi
+

--- a/scripts/validate-licenses.sh
+++ b/scripts/validate-licenses.sh
@@ -37,9 +37,9 @@ if [ $lines > 1 ]
 then
     echo -e "The following \033[1;31m $lines packages \033[0m have licenses that are not in the approved list. Please investigate their licenses and add them to the approved list if compatible with MIT or remove the dependency\n"
     print_unapproved
-    exit 1
+    # Exit 0 for now
+    exit 0
 else
     echo "All direct dependencies have approved licenses"
-    exit 0
 fi
 

--- a/scripts/validate-licenses.sh
+++ b/scripts/validate-licenses.sh
@@ -25,7 +25,7 @@ NR > 1{
 }
 END {
 }
-' devops/scripts/approved_licenses.csv)
+' devops/approved_licenses.csv)
 
 echo -e "\033[32mApproved licenses:\033[0m $approved \n"
 

--- a/scripts/validate-licenses.sh
+++ b/scripts/validate-licenses.sh
@@ -29,17 +29,17 @@ END {
 
 echo -e "\033[32mApproved licenses:\033[0m $approved \n"
 
-npx --ignore-existing license-checker --direct --production --excludePrivatePackages --exclude $approved --start . --csv --out unapproved.csv
+npx --ignore-existing license-checker --production --excludePrivatePackages --exclude $approved --start . --csv --out unapproved.csv
 
 lines=$(cat unapproved.csv | wc -l)
 
 if [ $lines > 1 ]
 then
-    echo -e "The following \033[1;31m $lines packages \033[0m have licenses that are not in the approved list. Please investigate their licenses and add them to the approved list if compatible with MIT or remove the dependency\n"
+    echo -e "::warning file=validate-licenses.sh::$lines packages have licenses that are not in the approved list. Please investigate their licenses and add them to the approved list if compatible with MIT or remove the dependency\n"
     print_unapproved
-    # Exit 0 for now
+    # Exit 0 with warning for now
     exit 0
 else
-    echo "All direct dependencies have approved licenses"
+    echo "\033[32mAll direct dependencies have approved licenses\033[0m"
 fi
 


### PR DESCRIPTION
* Added script to validate if package dependency licenses are on a list of known compatible MIT licenses. 
* Includes a csv of approved licenses and script that can be added to the workflow files of other repos. 

This step must run after the `build` step where `npm install` runs. This script always exits with 0 status, but will produce a warning message if there are any licenses that are not on the approved list. 