### PR TITLE
Fix/update zap scan docker

### DIFF
--- a/.github/workflows/account-api-zap-scan.yml
+++ b/.github/workflows/account-api-zap-scan.yml
@@ -9,15 +9,16 @@ jobs:
     name: Scan Account Mgmt API
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: master
       - name: ZAP Scan
-        uses: zaproxy/action-api-scan@v0.4.0
+        uses: zaproxy/action-api-scan@v0.8.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          docker_name: 'owasp/zap2docker-stable'
+          docker_name: 'ghcr.io/zaproxy/zaproxy:stable'
           allow_issue_writing: 'false'
+          format: 'openapi'
           target: 'https://api-easey-dev.app.cloud.gov/account-mgmt/swagger-json'
           rules_file_name: 'rules.tsv'
           cmd_options: "-a -d -z \"-config replacer.full_list\\(0\\).description=auth1 -config replacer.full_list\\(0\\).enabled=true -config replacer.full_list\\(0\\).matchtype=REQ_HEADER -config replacer.full_list\\(0\\).matchstr=x-api-key -config replacer.full_list\\(0\\).regex=false -config replacer.full_list\\(0\\).replacement=${{ secrets.OWASP_ZAP_SCAN_API_KEY }}\""

--- a/.github/workflows/auth-api-zap-scan.yml
+++ b/.github/workflows/auth-api-zap-scan.yml
@@ -9,14 +9,15 @@ jobs:
     name: Scan Auth Mgmt API
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: master
       - name: ZAP Scan
-        uses: zaproxy/action-api-scan@v0.4.0
+        uses: zaproxy/action-api-scan@v0.8.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          docker_name: 'owasp/zap2docker-stable'
+          docker_name: 'ghcr.io/zaproxy/zaproxy:stable'
+          format: 'openapi'
           allow_issue_writing: 'false'
           target: 'https://api-easey-dev.app.cloud.gov/auth-mgmt/swagger-json'
           rules_file_name: 'rules.tsv'

--- a/.github/workflows/camd-services-zap-scan.yaml
+++ b/.github/workflows/camd-services-zap-scan.yaml
@@ -13,7 +13,7 @@ jobs:
         with:
           ref: master
       - name: ZAP Scan
-        uses: zaproxy/action-api-scan@v0.4.0
+        uses: zaproxy/action-api-scan@v0.8.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           docker_name: 'ghcr.io/zaproxy/zaproxy:stable'

--- a/.github/workflows/camd-services-zap-scan.yaml
+++ b/.github/workflows/camd-services-zap-scan.yaml
@@ -9,14 +9,15 @@ jobs:
     name: Scan CAMD Administrative & General Services
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: master
       - name: ZAP Scan
         uses: zaproxy/action-api-scan@v0.4.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          docker_name: 'owasp/zap2docker-stable'
+          docker_name: 'ghcr.io/zaproxy/zaproxy:stable'
+          format: 'openapi'
           allow_issue_writing: 'false'
           target: 'https://api-easey-dev.app.cloud.gov/camd-services/swagger-json'
           rules_file_name: 'rules.tsv'

--- a/.github/workflows/emissions-api-zap-scan.yml
+++ b/.github/workflows/emissions-api-zap-scan.yml
@@ -9,14 +9,15 @@ jobs:
     name: Scan Emissions Mgmt API
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: master
       - name: ZAP Scan
-        uses: zaproxy/action-api-scan@v0.4.0
+        uses: zaproxy/action-api-scan@v0.8.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           docker_name: 'owasp/zap2docker-stable'
+          format: 'openapi'
           allow_issue_writing: 'false'
           target: 'https://api-easey-dev.app.cloud.gov/emissions-mgmt/swagger-json'
           rules_file_name: 'rules.tsv'

--- a/.github/workflows/emissions-api-zap-scan.yml
+++ b/.github/workflows/emissions-api-zap-scan.yml
@@ -16,7 +16,7 @@ jobs:
         uses: zaproxy/action-api-scan@v0.8.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          docker_name: 'owasp/zap2docker-stable'
+          docker_name: 'ghcr.io/zaproxy/zaproxy:stable'
           format: 'openapi'
           allow_issue_writing: 'false'
           target: 'https://api-easey-dev.app.cloud.gov/emissions-mgmt/swagger-json'

--- a/.github/workflows/facilities-api-zap-scan.yml
+++ b/.github/workflows/facilities-api-zap-scan.yml
@@ -16,7 +16,7 @@ jobs:
         uses: zaproxy/action-api-scan@v0.8.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          docker_name: 'owasp/zap2docker-stable'
+          docker_name: 'ghcr.io/zaproxy/zaproxy:stable'
           format: 'openapi'
           allow_issue_writing: 'false'
           target: 'https://api-easey-dev.app.cloud.gov/facilities-mgmt/swagger-json'

--- a/.github/workflows/facilities-api-zap-scan.yml
+++ b/.github/workflows/facilities-api-zap-scan.yml
@@ -9,14 +9,15 @@ jobs:
     name: Scan Facilities Mgmt API
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: master
       - name: ZAP Scan
-        uses: zaproxy/action-api-scan@v0.4.0
+        uses: zaproxy/action-api-scan@v0.8.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           docker_name: 'owasp/zap2docker-stable'
+          format: 'openapi'
           allow_issue_writing: 'false'
           target: 'https://api-easey-dev.app.cloud.gov/facilities-mgmt/swagger-json'
           rules_file_name: 'rules.tsv'

--- a/.github/workflows/mdm-api-zap-scan.yml
+++ b/.github/workflows/mdm-api-zap-scan.yml
@@ -11,15 +11,16 @@ jobs:
     name: Scan Master Data Mgmt API
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: master
       - name: ZAP Scan
-        uses: zaproxy/action-api-scan@v0.4.0
+        uses: zaproxy/action-api-scan@v0.8.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          docker_name: 'owasp/zap2docker-stable'
+          docker_name: 'ghcr.io/zaproxy/zaproxy:stable'
           allow_issue_writing: 'false'
+          format: 'openapi'
           target: 'https://api-easey-dev.app.cloud.gov/master-data-mgmt/swagger-json'
           rules_file_name: 'rules.tsv'
           cmd_options: "-a -d -z \"-config replacer.full_list\\(0\\).description=auth1 -config replacer.full_list\\(0\\).enabled=true -config replacer.full_list\\(0\\).matchtype=REQ_HEADER -config replacer.full_list\\(0\\).matchstr=x-api-key -config replacer.full_list\\(0\\).regex=false -config replacer.full_list\\(0\\).replacement=${{ secrets.OWASP_ZAP_SCAN_API_KEY }}\""

--- a/.github/workflows/monitor-plan-api-zap-scan.yml
+++ b/.github/workflows/monitor-plan-api-zap-scan.yml
@@ -9,15 +9,16 @@ jobs:
     name: Scan Monitor Plan Mgmt API
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: master
       - name: ZAP Scan
-        uses: zaproxy/action-api-scan@v0.4.0
+        uses: zaproxy/action-api-scan@v0.8.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           docker_name: 'owasp/zap2docker-stable'
           allow_issue_writing: 'false'
+          format: 'openapi'
           target: 'https://api-easey-dev.app.cloud.gov/monitor-plan-mgmt/swagger-json'
           rules_file_name: 'rules.tsv'
           cmd_options: "-a -d -z \"-config replacer.full_list\\(0\\).description=auth1 -config replacer.full_list\\(0\\).enabled=true -config replacer.full_list\\(0\\).matchtype=REQ_HEADER -config replacer.full_list\\(0\\).matchstr=x-api-key -config replacer.full_list\\(0\\).regex=false -config replacer.full_list\\(0\\).replacement=${{ secrets.OWASP_ZAP_SCAN_API_KEY }}\""

--- a/.github/workflows/monitor-plan-api-zap-scan.yml
+++ b/.github/workflows/monitor-plan-api-zap-scan.yml
@@ -16,7 +16,7 @@ jobs:
         uses: zaproxy/action-api-scan@v0.8.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          docker_name: 'owasp/zap2docker-stable'
+          docker_name: 'ghcr.io/zaproxy/zaproxy:stable'
           allow_issue_writing: 'false'
           format: 'openapi'
           target: 'https://api-easey-dev.app.cloud.gov/monitor-plan-mgmt/swagger-json'

--- a/.github/workflows/qa-cert-api-zap-scan.yaml
+++ b/.github/workflows/qa-cert-api-zap-scan.yaml
@@ -9,15 +9,16 @@ jobs:
     name: Scan QA Certification Mgmt API
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: master
       - name: ZAP Scan
-        uses: zaproxy/action-api-scan@v0.4.0
+        uses: zaproxy/action-api-scan@v0.8.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           docker_name: 'owasp/zap2docker-stable'
           allow_issue_writing: 'false'
+          format: 'openapi'
           target: 'https://api-easey-dev.app.cloud.gov/qa-certification-mgmt/swagger-json'
           rules_file_name: 'rules.tsv'
           cmd_options: "-a -d -z \"-config replacer.full_list\\(0\\).description=auth1 -config replacer.full_list\\(0\\).enabled=true -config replacer.full_list\\(0\\).matchtype=REQ_HEADER -config replacer.full_list\\(0\\).matchstr=x-api-key -config replacer.full_list\\(0\\).regex=false -config replacer.full_list\\(0\\).replacement=${{ secrets.OWASP_ZAP_SCAN_API_KEY }}\""

--- a/.github/workflows/qa-cert-api-zap-scan.yaml
+++ b/.github/workflows/qa-cert-api-zap-scan.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: zaproxy/action-api-scan@v0.8.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          docker_name: 'owasp/zap2docker-stable'
+          docker_name: 'ghcr.io/zaproxy/zaproxy:stable'
           allow_issue_writing: 'false'
           format: 'openapi'
           target: 'https://api-easey-dev.app.cloud.gov/qa-certification-mgmt/swagger-json'


### PR DESCRIPTION
Made the following updates:

- New location of the the zaproxy docker image (ghcr)
- Newer version of actions/checkout
- Newer version of the zap-api-scan action
- Added an explicit parameter for api format