### PR TITLE
Added hook to set scan strength

### DIFF
--- a/.github/workflows/mdm-api-zap-scan.yml
+++ b/.github/workflows/mdm-api-zap-scan.yml
@@ -23,7 +23,7 @@ jobs:
           format: 'openapi'
           target: 'https://api-easey-dev.app.cloud.gov/master-data-mgmt/swagger-json'
           rules_file_name: 'rules.tsv'
-          cmd_options: "-a -d -z \"-config replacer.full_list\\(0\\).description=auth1 -config replacer.full_list\\(0\\).enabled=true -config replacer.full_list\\(0\\).matchtype=REQ_HEADER -config replacer.full_list\\(0\\).matchstr=x-api-key -config replacer.full_list\\(0\\).regex=false -config replacer.full_list\\(0\\).replacement=${{ secrets.OWASP_ZAP_SCAN_API_KEY }}\""
+          cmd_options: "-a -d --hook=scan-hooks/api_scan.py -z \"-config replacer.full_list\\(0\\).description=auth1 -config replacer.full_list\\(0\\).enabled=true -config replacer.full_list\\(0\\).matchtype=REQ_HEADER -config replacer.full_list\\(0\\).matchstr=x-api-key -config replacer.full_list\\(0\\).regex=false -config replacer.full_list\\(0\\).replacement=${{ secrets.OWASP_ZAP_SCAN_API_KEY }}\""
       - name: Package reports
         run: scripts/zap-api-scan.sh easey-mdm-api
         env:

--- a/.github/workflows/streaming-services-zap-scan.yaml
+++ b/.github/workflows/streaming-services-zap-scan.yaml
@@ -13,11 +13,12 @@ jobs:
         with:
           ref: master
       - name: ZAP Scan
-        uses: zaproxy/action-api-scan@v0.4.0
+        uses: zaproxy/action-api-scan@v0.8.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          docker_name: 'owasp/zap2docker-stable'
+          docker_name: 'ghcr.io/zaproxy/zaproxy:stable'
           allow_issue_writing: 'false'
+          format: 'openapi'
           target: 'https://api-easey-dev.app.cloud.gov/streaming-services/swagger-json'
           rules_file_name: 'rules.tsv'
           cmd_options: "-a -d -z \"-config replacer.full_list\\(0\\).description=auth1 -config replacer.full_list\\(0\\).enabled=true -config replacer.full_list\\(0\\).matchtype=REQ_HEADER -config replacer.full_list\\(0\\).matchstr=x-api-key -config replacer.full_list\\(0\\).regex=false -config replacer.full_list\\(0\\).replacement=${{ secrets.OWASP_ZAP_SCAN_API_KEY }}\""

--- a/scan-hooks/api_scan.py
+++ b/scan-hooks/api_scan.py
@@ -1,0 +1,7 @@
+# Description: This file contains the API calls for the scan hooks.  
+# This hook sets the scan policy strength to 'high' and threshold to 'low'.
+# This active scan settings matches the what is used by the NCC
+# Note: this scan will take longer to complete and should therefore be run at off-peak times.
+
+def zap_active_scan(zap, target, policy):
+    return zap, target, 'St-High-Th-Low'


### PR DESCRIPTION
The scan configured with the GitHub action-api-scan does not match the scan strength used by the NCC to do the production scans.  This pull request includes a hook to set the scan strength to 'high' prior to running the API active scan.