### PR TITLE
update release v.16 auth-api version

### DIFF
--- a/scripts/deploy-list.txt
+++ b/scripts/deploy-list.txt
@@ -2,7 +2,7 @@ EASEY v1.6.131 facilities-api release/v1.6
 EASEY v1.6.103 account-api release/v1.6 
 EASEY v1.6.81 mdm-api release/v1.6 
 EASEY v1.6.139 emissions-api release/v1.6 
-EASEY v1.6.107 auth-api release/v1.6 
+EASEY v1.6.108 auth-api release/v1.6 
 EASEY v1.6.109 camd-services release/v1.6 
 EASEY v1.6.75 streaming-services release/v1.6 
 REACT_APP_EASEY v1.6.143 campd-ui release/v1.6 


### PR DESCRIPTION
Updated release v.16 auth-api version 

**v1.6.107 --> v1.6.108** ([Swagger Link](https://api.epa.gov/easey/staging/auth-mgmt/swagger/))
