### PR TITLE
Fix Build failures. sonarcloud-github-action has been deprecated

### DIFF
--- a/.github/workflows/reusable-build-workflow.yaml
+++ b/.github/workflows/reusable-build-workflow.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Run Unit Tests
         run: devops/scripts/yarn/unit-tests.sh
       - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: sonarsource/sonarqube-scan-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Fix Build failures. sonarcloud-github-action has been deprecated and replaced with sonarqube-scan-action